### PR TITLE
Fix: correct API naming from updateCardByIdCommon to deleteCardByIdCommon

### DIFF
--- a/services/client/cards.ts
+++ b/services/client/cards.ts
@@ -1,5 +1,5 @@
 import clientInstance from '@/utils/axiosClient';
-import { createCardCommon, getCardsCommon, updateCardCommon, getCardByIdCommon, updateCardByIdCommon } from '../common';
+import { createCardCommon, getCardsCommon, updateCardCommon, getCardByIdCommon, deleteCardByIdCommon } from '../common';
 
 export const createCard = (body: {
   assigneeUserId: number;
@@ -27,4 +27,4 @@ export const updateCard = (body: {
 
 export const getCardById = (query: { cardId: number }) => getCardByIdCommon(clientInstance, query);
 
-export const updateCardById = (query: { cardId: number }) => updateCardByIdCommon(clientInstance, query);
+export const deleteCardById = (query: { cardId: number }) => deleteCardByIdCommon(clientInstance, query);

--- a/services/common.ts
+++ b/services/common.ts
@@ -110,7 +110,7 @@ export const getCardByIdCommon = async (instance: AxiosInstance, { cardId }: { c
   }
 };
 
-export const updateCardByIdCommon = async (instance: AxiosInstance, { cardId }: { cardId: number }) => {
+export const deleteCardByIdCommon = async (instance: AxiosInstance, { cardId }: { cardId: number }) => {
   try {
     const response = await instance.delete(`/cards/${cardId}`);
     return response.data;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/services -> dev

### 변경 사항
update -> delete로 함수 명칭 변경 (기능이 delete인데 명칭이 update였음)

### 테스트 결과
